### PR TITLE
Add top-level go file to fix dep import in other projects

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package crypto contains tools to manipulate keys and signatures.
+package crypto


### PR DESCRIPTION
It's a good practice to always have a doc.go or main.go file at the top-level.
Package managers break if there's no go file at the top-level of the package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-crypto/8)
<!-- Reviewable:end -->
