### PR TITLE
Encryption and decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 // ...
 // -----END ED25519 PRIVATE KEY-----
 
-    // let's sign a messae
+    // let's sign a message
     message := "message"
     signature, err := signatures.Sign(priv, message)
     fmt.Println(string(signature.Signature))
@@ -132,16 +132,16 @@ import (
 func main() {
 	pub, priv, err := keys.GenerateKey(x509.RSA)
 	fmt.Println(string(priv))
-	// -----BEGIN ED25519 PRIVATE KEY-----
-	// MIIJKgIBAAKCAgEAySIguzsYqm4p+I5/DU0dkUasSHhzc0xPQsjBeR1/iNAoZP4n
+	// -----BEGIN RSA PRIVATE KEY-----
+    // MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKtI8b9kKcUDBE
 	// ...
-	// -----END ED25519 PRIVATE KEY-----
+	// -----END RSA PRIVATE KEY-----
 
-	// let's sign a messae
+	// let's encrypt a message
 	message := []byte("a very secret message")
 	ciphertext, err := encryption.Encrypt(pub, message)
 
-	// verify that the signature is valid
+	// and then decrypt it
 	plaintext, err := encryption.Decrypt(priv, ciphertext)
 	if err != nil {
 		panic("decryption failed !")
@@ -167,16 +167,16 @@ import (
 func main() {
 	pub, priv, err := keys.GenerateKey(x509.RSA)
 	fmt.Println(string(priv))
-	// -----BEGIN ED25519 PRIVATE KEY-----
-	// MIIJKgIBAAKCAgEAySIguzsYqm4p+I5/DU0dkUasSHhzc0xPQsjBeR1/iNAoZP4n
+	// -----BEGIN RSA PRIVATE KEY-----
+    // MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKtI8b9kKcUDBE
 	// ...
-	// -----END ED25519 PRIVATE KEY-----
+	// -----END RSA PRIVATE KEY-----
 
-	// let's sign a messae
+	// let's encrypt a message
 	message := []byte("a very secret message")
 	ciphertext, err := encryption.EncryptShort(pub, message)
 
-	// verify that the signature is valid
+	// and then decrypt it
 	plaintext, err := encryption.DecryptShort(priv, ciphertext)
 	if err != nil {
 		panic("decryption failed !")

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ func main() {
 This package lets you encrypt and decrypt messages. For now, only RSA keys are supported.
 We expose two different encryption schemes:
 
-- RSA-OAEP + AES-GCM to encrypt any size of message. The message is encrypted using a symmetric AES-GCM-256 key,
-  and that key is in turn encrypted using RSA-OAEP
+- RSA-OAEP + AES-GCM to encrypt any size of message. The message is first encrypted using a symmetric AES-GCM-256 with 12 byte IVs and 16 byte authentication tags.
+  The AES key is then encrypted using RSA-OAEP
 
 ```golang
 import (

--- a/README.md
+++ b/README.md
@@ -111,3 +111,78 @@ func main() {
 // my data
 }
 ```
+
+## encryption
+
+This package lets you encrypt and decrypt messages. For now, only RSA keys are supported.
+We expose two different encryption schemes:
+
+- RSA-OAEP + AES-GCM to encrypt any size of message. The message is encrypted using a symmetric AES-GCM-256 key,
+  and that key is in turn encrypted using RSA-OAEP
+
+```golang
+import (
+	"crypto/x509"
+	"fmt"
+
+	"github.com/stratumn/go-crypto/encryption"
+	"github.com/stratumn/go-crypto/keys"
+)
+
+func main() {
+	pub, priv, err := keys.GenerateKey(x509.RSA)
+	fmt.Println(string(priv))
+	// -----BEGIN ED25519 PRIVATE KEY-----
+	// MIIJKgIBAAKCAgEAySIguzsYqm4p+I5/DU0dkUasSHhzc0xPQsjBeR1/iNAoZP4n
+	// ...
+	// -----END ED25519 PRIVATE KEY-----
+
+	// let's sign a messae
+	message := []byte("a very secret message")
+	ciphertext, err := encryption.Encrypt(pub, message)
+
+	// verify that the signature is valid
+	plaintext, err := encryption.Decrypt(priv, ciphertext)
+	if err != nil {
+		panic("decryption failed !")
+	}
+
+	fmt.Println(string(plaintext))
+	// a very secret message
+}
+```
+
+- RSA-OAEP to encrypt short messages. The message is directly encrypted using the asymmetric algo.
+  The message size should be limited to keyLenBits / 8 - 42 = 214 bytes for 2048 RSA keys.
+
+```golang
+import (
+	"crypto/x509"
+	"fmt"
+
+	"github.com/stratumn/go-crypto/encryption"
+	"github.com/stratumn/go-crypto/keys"
+)
+
+func main() {
+	pub, priv, err := keys.GenerateKey(x509.RSA)
+	fmt.Println(string(priv))
+	// -----BEGIN ED25519 PRIVATE KEY-----
+	// MIIJKgIBAAKCAgEAySIguzsYqm4p+I5/DU0dkUasSHhzc0xPQsjBeR1/iNAoZP4n
+	// ...
+	// -----END ED25519 PRIVATE KEY-----
+
+	// let's sign a messae
+	message := []byte("a very secret message")
+	ciphertext, err := encryption.EncryptShort(pub, message)
+
+	// verify that the signature is valid
+	plaintext, err := encryption.DecryptShort(priv, ciphertext)
+	if err != nil {
+		panic("decryption failed !")
+	}
+
+	fmt.Println(string(plaintext))
+	// a very secret message
+}
+```

--- a/encryption/decrypt.go
+++ b/encryption/decrypt.go
@@ -76,7 +76,7 @@ func Decrypt(secretKey, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, ErrCouldNotDecrypt
 	}
-	gcm, err := cipher.NewGCMWithTagSize(c, tagLength)
+	gcm, err := cipher.NewGCM(c)
 	if err != nil {
 		return nil, ErrCouldNotDecrypt
 	}

--- a/encryption/decrypt.go
+++ b/encryption/decrypt.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encryption
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+
+	"github.com/pkg/errors"
+	"github.com/stratumn/go-crypto/keys"
+)
+
+// Decrypt decrypts a long message with the private key.
+// Only RSA keys are supported for now.
+// The ciphertext is actually composed of:
+// - a RSA-OAEP encrypted AES key
+// - an AES-256-GCM encrypted message
+// Returns the bytes of the plaintext.
+func Decrypt(secretKey, data []byte) ([]byte, error) {
+	sk, _, err := keys.ParseSecretKey(secretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts crypto.DecrypterOpts
+	switch sk.(type) {
+	case *rsa.PrivateKey:
+		opts = &rsa.OAEPOptions{Hash: crypto.SHA1}
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrNotImplemented
+	}
+
+	if len(data) < aesKeyLength*8 {
+		return nil, ErrCouldNotDecrypt
+	}
+
+	encryptedSymKey := data[:aesKeyLength*8]
+	cipherText := data[aesKeyLength*8:]
+
+	decrypter, ok := sk.(crypto.Decrypter)
+	if !ok {
+		return nil, errors.New("private key does not implement crypto.Decrypter")
+	}
+
+	aesKey, err := decrypter.Decrypt(rand.Reader, encryptedSymKey, opts)
+	if err != nil {
+		return nil, ErrCouldNotDecrypt
+	}
+
+	// The decrypted AES key is base64 encoded, we have to decode it.
+	aesKey, err = base64.StdEncoding.DecodeString(string(aesKey))
+	if err != nil {
+		return nil, ErrCouldNotDecrypt
+	}
+
+	c, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, ErrCouldNotDecrypt
+	}
+	gcm, err := cipher.NewGCMWithTagSize(c, tagLength)
+	if err != nil {
+		return nil, ErrCouldNotDecrypt
+	}
+
+	iv := cipherText[0:ivLength]
+	msg := cipherText[ivLength:]
+
+	res, err := gcm.Open(nil, iv, msg, nil)
+	if err != nil {
+		return nil, ErrCouldNotDecrypt
+	}
+
+	return res, nil
+}
+
+// DecryptShort decrypt a short message.
+// for 2048-bit RSA keys, the max message size is 214 bytes.
+// Only RSA keys are supported for now.
+// The message is directly RSA-OAEP decrypted.
+// Returns the bytes of the plaintext.
+func DecryptShort(secretKey, data []byte) ([]byte, error) {
+	sk, _, err := keys.ParseSecretKey(secretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts crypto.DecrypterOpts
+	switch sk.(type) {
+	case *rsa.PrivateKey:
+		opts = &rsa.OAEPOptions{Hash: crypto.SHA1}
+	default:
+		return nil, ErrNotImplemented
+	}
+
+	decrypter, ok := sk.(crypto.Decrypter)
+	if !ok {
+		return nil, errors.New("private key does not implement crypto.Decrypter")
+	}
+
+	return decrypter.Decrypt(rand.Reader, data, opts)
+}

--- a/encryption/decrypt.go
+++ b/encryption/decrypt.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Stratumn SAS. All rights reserved.
+// Copyright 2019 Stratumn SAS. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/encryption/encrypt.go
+++ b/encryption/encrypt.go
@@ -1,0 +1,106 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/stratumn/go-crypto/keys"
+)
+
+// Encrypt encrypt a long message with the private key.
+// Only RSA keys are supported for now.
+// The message is first encrypted with AES-256-GCM with a random key.
+// The we encrypt the AES key with the public key.
+// Returns the bytes of the ciphertext.
+func Encrypt(publicKey, data []byte) ([]byte, error) {
+
+	// Generate a random 256-bit key.
+	aesKey := make([]byte, aesKeyLength)
+	_, err := rand.Read(aesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encrypt the message with AES-256-GCM.
+	c, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCMWithTagSize(c, tagLength)
+	if err != nil {
+		return nil, err
+	}
+
+	iv := make([]byte, ivLength)
+	_, err = rand.Read(iv)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, iv, data, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pk, _, err := keys.ParsePublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// We encrypt the base64 encoding of the AES key...
+	// Same thing is done in @stratumn/js-crypto
+	aesKeyB64 := []byte(base64.StdEncoding.EncodeToString(aesKey))
+	var encryptedSymKey []byte
+
+	switch pk.(type) {
+	case *rsa.PublicKey:
+		encryptedSymKey, err = rsa.EncryptOAEP(sha1.New(), rand.Reader, pk.(*rsa.PublicKey), aesKeyB64, nil)
+	default:
+		return nil, ErrNotImplemented
+	}
+
+	res := make([]byte, len(encryptedSymKey)+len(iv)+len(ciphertext))
+	res = append(encryptedSymKey, iv...)
+	res = append(res, ciphertext...)
+
+	return res, nil
+}
+
+// EncryptShort encrypts a short message.
+// for 2048-bit RSA keys, the max message size is 214 bytes.
+// Only RSA keys are supported for now.
+// The message is directly RSA-OAEP encrypted.
+// Returns the bytes of the ciphertext.
+func EncryptShort(publicKey, data []byte) ([]byte, error) {
+	pk, _, err := keys.ParsePublicKey(publicKey)
+	if err != nil {
+		fmt.Println("============================")
+		return nil, err
+	}
+
+	switch pk.(type) {
+	case *rsa.PublicKey:
+		return rsa.EncryptOAEP(sha1.New(), rand.Reader, pk.(*rsa.PublicKey), data, nil)
+	default:
+		return nil, ErrNotImplemented
+	}
+}

--- a/encryption/encrypt.go
+++ b/encryption/encrypt.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/stratumn/go-crypto/keys"
 )
@@ -95,7 +94,6 @@ func Encrypt(publicKey, data []byte) ([]byte, error) {
 func EncryptShort(publicKey, data []byte) ([]byte, error) {
 	pk, _, err := keys.ParsePublicKey(publicKey)
 	if err != nil {
-		fmt.Println("============================")
 		return nil, err
 	}
 

--- a/encryption/encrypt.go
+++ b/encryption/encrypt.go
@@ -44,7 +44,7 @@ func Encrypt(publicKey, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	gcm, err := cipher.NewGCMWithTagSize(c, tagLength)
+	gcm, err := cipher.NewGCM(c)
 	if err != nil {
 		return nil, err
 	}

--- a/encryption/encrypt.go
+++ b/encryption/encrypt.go
@@ -74,12 +74,14 @@ func Encrypt(publicKey, data []byte) ([]byte, error) {
 	switch pk.(type) {
 	case *rsa.PublicKey:
 		encryptedSymKey, err = rsa.EncryptOAEP(sha1.New(), rand.Reader, pk.(*rsa.PublicKey), aesKeyB64, nil)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, ErrNotImplemented
 	}
 
-	res := make([]byte, len(encryptedSymKey)+len(iv)+len(ciphertext))
-	res = append(encryptedSymKey, iv...)
+	res := append(encryptedSymKey, iv...)
 	res = append(res, ciphertext...)
 
 	return res, nil

--- a/encryption/encrypt.go
+++ b/encryption/encrypt.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Stratumn SAS. All rights reserved.
+// Copyright 2019 Stratumn SAS. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package encryption is used to encrypt and decrypt data using asymmetric algorithms.
+// We expose methods to encrypt long messages (>256 bits) and shorts messages (<256 bits).
+package encryption
+
+import "github.com/pkg/errors"
+
+// ErrNotImplemented is the error returned when trying to sign a message with an unimplemented algorithm.
+var (
+	// ErrCouldNotDecrypt is returned when the message decryption has failed for crypto reasons.
+	ErrCouldNotDecrypt = errors.New("could not decrypt the message")
+
+	// ErrNotImplemented is returned when trying to use an  algo that does not handle encryption.
+	ErrNotImplemented = errors.New("Unhandled encryption algorithm")
+)
+
+const (
+	ivLength     = 12
+	tagLength    = 16
+	aesKeyLength = 32
+)

--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -28,6 +28,5 @@ var (
 
 const (
 	ivLength     = 12
-	tagLength    = 16
 	aesKeyLength = 32
 )

--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -18,12 +18,11 @@ package encryption
 
 import "github.com/pkg/errors"
 
-// ErrNotImplemented is the error returned when trying to sign a message with an unimplemented algorithm.
 var (
 	// ErrCouldNotDecrypt is returned when the message decryption has failed for crypto reasons.
 	ErrCouldNotDecrypt = errors.New("could not decrypt the message")
 
-	// ErrNotImplemented is returned when trying to use an  algo that does not handle encryption.
+	// ErrNotImplemented is returned when trying to use an algo that does not handle encryption.
 	ErrNotImplemented = errors.New("Unhandled encryption algorithm")
 )
 

--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Stratumn SAS. All rights reserved.
+// Copyright 2019 Stratumn SAS. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/encryption/encryption_test.go
+++ b/encryption/encryption_test.go
@@ -1,0 +1,131 @@
+package encryption
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stratumn/go-crypto/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
+)
+
+var (
+	message = []byte("coucou, tu veux voir mon message ?")
+
+	rsaSk = []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDBsNAxEZ0pqCJq\nmFfADdx20uxx74kCFVI38QC0tPQGeaPIiL4z5/gCRzsWLhrUUCal83oaYKONmWcr\nF0z7+nXm+szjXq7Mp6G43VYVpZNxvBAqPg94e6AdKqtuZn+XRCLZhoSpefUqkJzB\nfze37Eohb7wf/JFutNweEmzpg77EL0D/RsBAuBnDJyvWeATaFB53Ip1SEBlIHyPH\n0Io0FXPLZS3TR4SKWykaekNubLZe9itNn5S1RPHLbK+Hz9f9BowMnEriOziOZa4A\ndhqnHw7ukWo08VkyJsVRwdvccwYz9QPeCtk0rXyubgWKQ1n/26XU7tyXT8qj0BQ7\nBWkMQaPRAgMBAAECggEBAJ85bfxYgX1EJX7BW6ma+3iG7i6/fj7DLkKkkTL8anqE\nNnrcxpc/A2dEDTOvlQiiFxNnMyJJ/UmjKOeIkRW3kILf+9yR8lp1F4I0GddTtQDT\nW+qN+APQhRBVCnaINi0wqwFtDtOPWVazaNm8bh55VXtlMh6NbzS14xmphfT1A7ab\nvn5be3L5FzRQEIhai6Uqc2SY3iAfc+honElnYwL0ND7hoU+wJgs8Btvb2Um3fMA5\n4WDM0tSrLCnGMzCjn9PuROQav0F8nEqq3/zAEB1UBCjNitUnjGUDNGsWM4/GtWDs\nR12H0Vg9Pb4nfnPPfD8PWUuTNhD/RTzeP73BS1SaJcECgYEA8oI8DtZFEsNXfeq7\nqw079+FAWjB14HXwyhZsl2Qd8jlahpRfUH0HUGsHBT4bydYtfvyJ2yjza/fhZdZC\nk1wTPGp84y5WAvGqkYAsPDbM3Fez7O1PQ4ZJw7JYW/mjo2r+3KYKLixshVaWDcAC\nF5J10cp6R8DEMejBs9VKSwhJDFkCgYEAzHdSH0J3MtKY36B2iwBFn5fTeKyFhLsQ\n7dVG8R+22Sd17rNtUeG0yn4RFK36GRLgPl4kRYlrfLBiXbVqdtBfUaffvoteTv6k\n++86KQjSo7veUCsRkT9HSB4+G7vQ59v3IqwYpCbFe5iwgufCPsVJskBnfMAhNqni\nxFYB2yKghDkCgYEA45isyvP34bMpcsiRluiVxn9FyR9AEgg+kztWcQMKQ+Hl/vZT\nOhQNgEDiVt5CcDwteMeEjgYx5ru+c7gRxYEdoI8EZKaBHMQ4Y9PaMCzyOT2qZIsX\n3/SxWBQSb0esd1uck/LVDR6uPrnTnFX+4KaZIuqXtq3ItFqRKLjdv+unuwkCgYBk\nwK9g4/mku43FNGb1m86zE7eLEUhB3YQ8DgqFKuGJJB7C3vuRi6zw0ypLjGdfD6Qc\nV3t8IHks2iW+k3TA03EE5bolRLvWJTjbREjei5BwSlUEIBTqA8p2SSDFvcj1V7jy\nBueli81oWBcyik13bPQhuAbGvE4hh5lMsiz79JYwUQKBgQDTwiOYbrrB/zNS6VdP\nn8Q0GxDbvDQRd0JjCp7aw4cX9g+gvsX9CETocAPQXpBD+f/6+Y5pvJN8BoZKdSqF\nHDIuKefy+M1zAbIbFLmWBNQZCUlq57jOZ/1BG3Y/qO3FD869ltwA/lYjUYv2pfGY\nRLJR2hWagXEb4vUCyY/Hhplv5A==\n-----END RSA PRIVATE KEY-----\n")
+	rsaPk = []byte("-----BEGIN RSA PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwbDQMRGdKagiaphXwA3c\ndtLsce+JAhVSN/EAtLT0BnmjyIi+M+f4Akc7Fi4a1FAmpfN6GmCjjZlnKxdM+/p1\n5vrM416uzKehuN1WFaWTcbwQKj4PeHugHSqrbmZ/l0Qi2YaEqXn1KpCcwX83t+xK\nIW+8H/yRbrTcHhJs6YO+xC9A/0bAQLgZwycr1ngE2hQedyKdUhAZSB8jx9CKNBVz\ny2Ut00eEilspGnpDbmy2XvYrTZ+UtUTxy2yvh8/X/QaMDJxK4js4jmWuAHYapx8O\n7pFqNPFZMibFUcHb3HMGM/UD3grZNK18rm4FikNZ/9ul1O7cl0/Ko9AUOwVpDEGj\n0QIDAQAB\n-----END RSA PUBLIC KEY-----\n")
+)
+
+func TestDecrypt(t *testing.T) {
+	t.Run("RSA", func(t *testing.T) {
+		ciphertext, _ := base64.StdEncoding.DecodeString("N1TWMI4rpB9YBQCO3V0BkHIVW7Q0Z+Bh3A8qiHXPGKkWA34HNiWdb1jqqyjIy5QamWZjJFTs8Hvt3o2YLEbf3/KIvZs1rajuVP/jvU1OlQ7oFlmqKdtuFMnIJhTavmFMDtAujzotZOb7Foogqh7PE7Ud0u9NBl3OKIWTrj2YUg+lRs1k7RGN9oi786ITd6UATcQ7CWA58QIv6uzNaMeIVKJEwdemiKZ9mxMQlCtErcgP3yBBTECwHQj0qJeYlqIz8nC4Bmk7WzlKJtaZyvvoXeBqem8o7TVo3ZbWs9+3pDMwMQkIvh12jJj2LRhohtgpYVJjiiWnZmfwjmf1+uQgMTvOug6PzYb1UTJzYc0pXY2o756GEMkTpK+wmzXgn2jwEzf772eVZS15FlSeHJcvHMxuPakXE+pLN117X8p/")
+
+		pt, err := Decrypt(rsaSk, ciphertext)
+		require.NoError(t, err)
+
+		assert.Equal(t, message, pt)
+	})
+
+	t.Run("ECDSA", func(t *testing.T) {
+		sk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		encoded, _ := keys.EncodeSecretkey(sk)
+
+		_, err := Decrypt(encoded, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+
+	t.Run("ED25519", func(t *testing.T) {
+		_, sk, _ := ed25519.GenerateKey(rand.Reader)
+		encoded, _ := keys.EncodeSecretkey(&sk)
+
+		_, err := Decrypt(encoded, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+}
+
+func TestDecryptShort(t *testing.T) {
+	t.Run("RSA", func(t *testing.T) {
+		shortCiphertext, _ := base64.StdEncoding.DecodeString("A9ZtekEBvZBbxsLG36C8Nc0RLMPQL6uDhZ+E7bRGiQBgW9MdyI5niizNRCgx71OxQEuMGYWGuFrvTnP79sJ3z8PEq3OneYrmghU+dw5BfrvsXpvOkw4SUulV5EnwjrAvLvWtfkAelVQWsYte/xalSMv4NHMitui1SD/SUQnqg64u/afp53z5PRXKW5VOVl5yrprXOJ2KL6rTxijz/m3DLOefGzaFhW4LgYLjaebZ1upHEci8h6Mz/KI2GyciNAM+bt7FtEEntX8PRJVuIKPbds3arIUQBaYbBVt3QKqbd7KhHfwfw8sRT28O0wapz8KPNaOWmWKDDusz7NtKf52Phg==")
+
+		pt, err := DecryptShort(rsaSk, shortCiphertext)
+		require.NoError(t, err)
+
+		assert.Equal(t, message, pt)
+	})
+
+	t.Run("ECDSA", func(t *testing.T) {
+		sk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		encoded, _ := keys.EncodeSecretkey(sk)
+
+		_, err := DecryptShort(encoded, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+
+	t.Run("ED25519", func(t *testing.T) {
+		_, sk, _ := ed25519.GenerateKey(rand.Reader)
+		encoded, _ := keys.EncodeSecretkey(&sk)
+
+		_, err := DecryptShort(encoded, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+}
+
+func TestEncrypt(t *testing.T) {
+	t.Run("RSA", func(t *testing.T) {
+		ct, err := Encrypt(rsaPk, message)
+		require.NoError(t, err)
+
+		pt, err := Decrypt(rsaSk, ct)
+		require.NoError(t, err)
+
+		assert.Equal(t, message, pt)
+	})
+
+	t.Run("ECDSA", func(t *testing.T) {
+		sk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		pkBytes, _ := keys.EncodePublicKey(sk.Public())
+
+		_, err := Encrypt(pkBytes, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+
+	t.Run("ED25519", func(t *testing.T) {
+		pk, _, _ := ed25519.GenerateKey(rand.Reader)
+		pkBytes, _ := keys.EncodePublicKey(&pk)
+
+		_, err := EncryptShort(pkBytes, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+}
+
+func TestEncryptShort(t *testing.T) {
+	t.Run("RSA", func(t *testing.T) {
+		ct, err := EncryptShort(rsaPk, message)
+		require.NoError(t, err)
+
+		pt, err := DecryptShort(rsaSk, ct)
+		require.NoError(t, err)
+
+		assert.Equal(t, message, pt)
+	})
+
+	t.Run("ECDSA", func(t *testing.T) {
+		sk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		pkBytes, _ := keys.EncodePublicKey(sk.Public())
+
+		_, err := EncryptShort(pkBytes, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+
+	t.Run("ED25519", func(t *testing.T) {
+		pk, _, _ := ed25519.GenerateKey(rand.Reader)
+		pkBytes, _ := keys.EncodePublicKey(&pk)
+
+		_, err := EncryptShort(pkBytes, []byte("123"))
+		assert.EqualError(t, err, ErrNotImplemented.Error())
+	})
+}

--- a/encryption/encryption_test.go
+++ b/encryption/encryption_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package encryption
 
 import (

--- a/encryption/encryption_test.go
+++ b/encryption/encryption_test.go
@@ -97,7 +97,7 @@ func TestEncrypt(t *testing.T) {
 		pk, _, _ := ed25519.GenerateKey(rand.Reader)
 		pkBytes, _ := keys.EncodePublicKey(&pk)
 
-		_, err := EncryptShort(pkBytes, []byte("123"))
+		_, err := Encrypt(pkBytes, []byte("123"))
 		assert.EqualError(t, err, ErrNotImplemented.Error())
 	})
 }


### PR DESCRIPTION
Implement encryption and decryption the same way we did for js-crypto.

Everything is fine except the fact the we have to base64 encode the AES key before encrypting it...
This is due to the fact that we use `symmetricKey.export();` here https://github.com/stratumn/js-crypto/blob/master/src/keys/rsa.js#L84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-crypto/13)
<!-- Reviewable:end -->
